### PR TITLE
"allowers" typo correction and "SQLite" naming standard

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
                         </div>
                         <div class="s-sidebarwidget--content">
                             An open source tool for running arbitrary queries against a SQL Server data source from the web.
-                            This powers https://data.stackexchange.com/ and allowers users to query Stack Exchange data.
+                            This powers https://data.stackexchange.com/ and allow users to query Stack Exchange data.
                         </div>
                         <div class="s-sidebarwidget--content py8">
                             <div class="grid gs4">
@@ -127,7 +127,7 @@
                             <a class="s-sidebarwidget--action" href="https://www.nuget.org/packages/Dapper">NuGet</a>
                         </div>
                         <div class="s-sidebarwidget--content">
-                            A high performance Micro-ORM supporting SQL Server, MySQL, Sqlite, SqlCE, Firebird, etc.
+                            A high performance Micro-ORM supporting SQL Server, MySQL, SQLite, SqlCE, Firebird, etc.
                         </div>
                         <div class="s-sidebarwidget--content py8">
                             <div class="grid gs4">


### PR DESCRIPTION
"allowers" typo correction and "SQLite" naming standard